### PR TITLE
Session.js namespacing should be against key, not value.

### DIFF
--- a/js/session.js
+++ b/js/session.js
@@ -28,14 +28,14 @@
   }
 
   Session.prototype.set = function (key, value) {
-    if (this.options.namespace) key = this.options.namespace + '.' + value
+    if (this.options.namespace) key = this.options.namespace + '.' + key
 
-    this.data[key] = value
+    this.data[key] = key
     this.saveSession()
   }
 
   Session.prototype.get = function (key) {
-    if (this.options.namespace) key = this.options.namespace + '.' + value
+    if (this.options.namespace) key = this.options.namespace + '.' + key
 
     return this.data[key]
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/410825/9942755/d929323c-5d4a-11e5-804c-c63709351cc3.png)

Namespace is gumbo, of course. Ignore the 'unite'. 
